### PR TITLE
Fix when launching containers as root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ ps:
 down:
 	docker-compose down
 	docker-compose -f regression/docker-compose.yml down
+	@rm -f images/p1.qcow2 && echo "removing images/p1.qcow2"
 
 clean:
 	docker system prune -f

--- a/src/create_apply_group.sh
+++ b/src/create_apply_group.sh
@@ -10,11 +10,15 @@ if [ -z "$PUBLICKEY" ]; then
 fi
 
 if [ ! -f "/u/$PUBLICKEY" ]; then
-  >&2 echo "WARNING: Can't read ssh public key file $PUBLICKEY. Creating user 'lab' with same root password"
+  >&2 echo "WARNING: Can't read ssh public key file $PUBLICKEY. Creating user 'lab' with same password as root"
   SSHUSER="lab"
 else
   SSHUSER=$(cat /u/$PUBLICKEY | cut -d' ' -f3 | cut -d'@' -f1)
   SSHPUBLIC="ssh-rsa \"$(cat /u/$PUBLICKEY)\""
+  if [ "root" == $SSHUSER ]; then
+    SSHUSER="lab"
+    >&2 echo "Creating user 'lab' with same password as root and ssh public key"
+  fi
 fi
 
 >&2 echo "default route:"


### PR DESCRIPTION
Fix for issue https://github.com/Juniper/OpenJNPR-Container-vMX/issues/7

User lab gets created, sharing root's password and ssh public key. This allows the root user to log in as root and lab user.
