### PR TITLE
Support for IPv6 address on fxp0. 

### DIFF
--- a/getpass.sh
+++ b/getpass.sh
@@ -10,9 +10,9 @@ fi
 
 list=$(docker ps --format '{{.Names}}')
 for vmx in $list; do
-  descr=$(docker logs $vmx | grep 'root password' | cut -d' ' -f1-4,7 | tr -d '\r' || echo $vmx)
+  descr=$(docker logs $vmx | grep 'root password' | cut -d' ' -f1-5,8 | tr -d '\r' || echo $vmx)
   if [ ! -z "$descr" ]; then
-    ip=$(docker logs $vmx | grep 'root password'|cut -d\( -f2|cut -d\) -f1)
+    ip=$(docker logs $vmx | grep 'root password'| awk -F'v4:' '{print $2}' | awk '{print $1}')
     fpcmem=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=1 $ip $CLI show chassis fpc 0 2>/dev/null | grep Online | awk '{print $9}')
     fpcmem="${fpcmem:-0}"
     if [ "$fpcmem" -gt "1024" ]; then

--- a/src/create_apply_group.sh
+++ b/src/create_apply_group.sh
@@ -33,10 +33,10 @@ if [ -z "$myip" ]; then
 else
   ip4cfg="family inet { address $myip; }"
 fi
-if [ -z "$myip6" ]; then
+if [ -z "$myipv6" ]; then
   ip6cfg=""
 else
-  ip6cfg="family inet6 { address $myip6mask; }"
+  ip6cfg="family inet6 { address $myipv6; }"
 fi
 
 cat <<EOF

--- a/src/launch.sh
+++ b/src/launch.sh
@@ -59,7 +59,7 @@ myipv6=$(ip addr show dev eth0 | awk '/inet6/ {print $2}' | head -1)
 echo "Interface $eth IPv6 address $myipv6"
 # bridge eth0 to fxp0 via br-ext, remove ip and change mac address of eth0
 mymac=$(cat /sys/class/net/eth0/address)
-echo "Bridging $eth ($myipmask/$mymac) with fxp0"
+echo "Bridging eth0 ($myip|$myipv6|$mymac) with fxp0"
 brctl addbr br-ext
 ip link set up br-ext
 ip tuntap add dev fxp0 mode tap
@@ -85,8 +85,9 @@ fi
 /create_apply_group.sh >> /tmp/$CONFIG
 
 ip=$(echo "$myip" | cut -d/ -f1)
+ip6=$(echo "$myipv6" | cut -d/ -f1)
 echo "-----------------------------------------------------------------------"
-echo "vMX $hostname ($ip) $RELEASE root password $rootpassword"
+echo "vMX $hostname (v4:$ip v6:$ip6) $RELEASE root password $rootpassword"
 echo "-----------------------------------------------------------------------"
 echo ""
 


### PR DESCRIPTION
Need docker-compose 2.x file format to use IPv6 addresses in docker networks. See issue #9 