### PR TITLE
Update core_mapping interface configuration

### DIFF
--- a/src/Dockerfile.bionic
+++ b/src/Dockerfile.bionic
@@ -21,7 +21,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY riot.patch create_config_drive.sh launch.sh \
   create_apply_group.sh create_ephemeral_db.sh \
-  system_check.sh start_pfe.sh fix_network_order.sh /
+  system_check.sh start_pfe.sh fix_network_order.sh update_core_mapping.sh /
 
 COPY riot_init.conf /etc/riot/
 COPY vmxt_init.conf /etc/vmxt/

--- a/src/Dockerfile.trusty
+++ b/src/Dockerfile.trusty
@@ -32,7 +32,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY riot.patch create_config_drive.sh launch.sh \
   create_apply_group.sh create_ephemeral_db.sh \
-  system_check.sh start_pfe.sh fix_network_order.sh update_coremapping.sh /
+  system_check.sh start_pfe.sh fix_network_order.sh update_core_mapping.sh /
 
 COPY riot_init.conf /etc/riot/
 COPY vmxt_init.conf /etc/vmxt/

--- a/src/Dockerfile.trusty
+++ b/src/Dockerfile.trusty
@@ -32,7 +32,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY riot.patch create_config_drive.sh launch.sh \
   create_apply_group.sh create_ephemeral_db.sh \
-  system_check.sh start_pfe.sh fix_network_order.sh /
+  system_check.sh start_pfe.sh fix_network_order.sh update_coremapping.sh /
 
 COPY riot_init.conf /etc/riot/
 COPY vmxt_init.conf /etc/vmxt/

--- a/src/launch.sh
+++ b/src/launch.sh
@@ -54,6 +54,8 @@ until ip link show $WAITFOR; do
   sleep 5
 done
 
+/update_core_mapping.sh
+
 rootpassword=$(pwgen 24 1)
 hostname=$(docker ps --format '{{.Names}}' -f id=$HOSTNAME)
 hostname="${hostname:-$HOSTNAME}"

--- a/src/update_core_mapping.sh
+++ b/src/update_core_mapping.sh
@@ -11,7 +11,7 @@ write_intf_core_mapping()
     fpc_intf_type="af_packet"
     ix_port=$1
     intf=$2
-    io_cpu="1"
+    io_cpu="$3"
     line_num="2"
     line_num=$(expr $line_num + $(cat  ${core_mapping_file}.cfg |grep ix_port | wc -l))
     if grep -qe "^$intf" ${core_mapping_file}.cfg; then
@@ -22,9 +22,10 @@ write_intf_core_mapping()
 }
 
 core_mapping_file="/usr/share/pfe/core_mapping"
+io_core="${IO_CORE:-1}"
 
 ix_port=0
 for intf in $(ls /sys/class/net | grep 'eth[1-9][0-9]*'); do
-    write_intf_core_mapping $ix_port $intf
+    write_intf_core_mapping $ix_port $intf $io_core
     ((ix_port += 1))
 done

--- a/src/update_core_mapping.sh
+++ b/src/update_core_mapping.sh
@@ -22,7 +22,7 @@ write_intf_core_mapping()
 }
 
 core_mapping_file="/usr/share/pfe/core_mapping"
-io_core="${IO_CORE:-1}"
+io_core="1"
 
 ix_port=0
 for intf in $(ls /sys/class/net | grep 'eth[1-9][0-9]*'); do

--- a/src/update_core_mapping.sh
+++ b/src/update_core_mapping.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) 2021, Juniper Networks, Inc.
+# All rights reserved.
+#
+
+echo "$0: Update interace core_mapping"
+
+write_intf_core_mapping()
+{
+    # parse interfaces.
+    fpc_intf_type="af_packet"
+    ix_port=$1
+    intf=$2
+    io_cpu="1"
+    line_num="2"
+    line_num=$(expr $line_num + $(cat  ${core_mapping_file}.cfg |grep ix_port | wc -l))
+    if grep -qe "^$intf" ${core_mapping_file}.cfg; then
+        sed -i "s/^$intf.*/$intf    ix_port=${ix_port}      rx_cpu=${io_cpu}        tx_cpu=${io_cpu}        $fpc_intf_type/" ${core_mapping_file}.cfg
+    else
+        sed -i "${line_num}i$intf      ix_port=${ix_port}      rx_cpu=${io_cpu}        tx_cpu=${io_cpu}        $fpc_intf_type" ${core_mapping_file}.cfg
+    fi
+}
+
+core_mapping_file="/usr/share/pfe/core_mapping"
+
+ix_port=0
+for intf in $(ls /sys/class/net | grep 'eth[1-9][0-9]*'); do
+    write_intf_core_mapping $ix_port $intf
+    ((ix_port += 1))
+done


### PR DESCRIPTION
If interfaces are added to the CVMX container outside of docker
control (e.g. by stitching veth-pairs to interconnect CVMX instances),
the interfaces were not detected during startup and as a consequence
RIOT did not startup correctly.

Added new configuration script that is called after all interfaces are
attached and up.