### PR TITLE
Make check for privileged container work with cgroup v2

### DIFF
--- a/src/system_check.sh
+++ b/src/system_check.sh
@@ -44,7 +44,7 @@ else
 fi
 
 echo -n "Check for container privileged mode ...... "
-echo "hello" 2>/dev/null > /sys/fs/cgroup/aaa
+mkdir /sys/fs/cgroup/aaa 2> /dev/null
 if [ $? -eq 0 ]; then
   echo yes
 else


### PR DESCRIPTION
When running on top of a distribution using cgroup v2 (Debian
Bullseye, Fedora >= 31, Arch), creating a file at the base of the
hierarchy is not possible. However, we can create a directory.